### PR TITLE
Minimal changes to work with graphql-java v4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>3.0.0</version>
+            <version>4.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/io/leangen/graphql/execution/complexity/ComplexityAnalysisInstrumentation.java
+++ b/src/main/java/io/leangen/graphql/execution/complexity/ComplexityAnalysisInstrumentation.java
@@ -4,16 +4,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import graphql.ExecutionResult;
 import graphql.execution.instrumentation.Instrumentation;
 import graphql.execution.instrumentation.InstrumentationContext;
 import graphql.execution.instrumentation.NoOpInstrumentation;
-import graphql.execution.instrumentation.parameters.DataFetchParameters;
-import graphql.execution.instrumentation.parameters.ExecutionParameters;
-import graphql.execution.instrumentation.parameters.FieldFetchParameters;
-import graphql.execution.instrumentation.parameters.FieldParameters;
-import graphql.execution.instrumentation.parameters.ValidationParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationDataFetchParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationExecutionStrategyParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldParameters;
+import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters;
 import graphql.language.AstPrinter;
 import graphql.language.Document;
 import graphql.validation.ValidationError;
@@ -31,22 +33,22 @@ public class ComplexityAnalysisInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginExecution(ExecutionParameters parameters) {
+    public InstrumentationContext<ExecutionResult> beginExecution(InstrumentationExecutionParameters parameters) {
         return NoOpInstrumentation.INSTANCE.beginExecution(parameters);
     }
 
     @Override
-    public InstrumentationContext<Document> beginParse(ExecutionParameters parameters) {
+    public InstrumentationContext<Document> beginParse(InstrumentationExecutionParameters parameters) {
         return NoOpInstrumentation.INSTANCE.beginParse(parameters);
     }
 
     @Override
-    public InstrumentationContext<List<ValidationError>> beginValidation(ValidationParameters parameters) {
+    public InstrumentationContext<List<ValidationError>> beginValidation(InstrumentationValidationParameters parameters) {
         return NoOpInstrumentation.INSTANCE.beginValidation(parameters);
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginDataFetch(DataFetchParameters parameters) {
+    public InstrumentationContext<ExecutionResult> beginDataFetch(InstrumentationDataFetchParameters parameters) {
         ResolvedField root = new ComplexityAnalyzer(complexityFunction, maximumComplexity).collectFields(parameters.getExecutionContext());
         if (log.isDebugEnabled()) {
             log.debug("Operation {} has total complexity of {}",
@@ -58,12 +60,18 @@ public class ComplexityAnalysisInstrumentation implements Instrumentation {
     }
 
     @Override
-    public InstrumentationContext<ExecutionResult> beginField(FieldParameters parameters) {
+    public InstrumentationContext<ExecutionResult> beginField(InstrumentationFieldParameters parameters) {
         return NoOpInstrumentation.INSTANCE.beginField(parameters);
     }
 
     @Override
-    public InstrumentationContext<Object> beginFieldFetch(FieldFetchParameters parameters) {
+    public InstrumentationContext<Object> beginFieldFetch(InstrumentationFieldFetchParameters parameters) {
         return NoOpInstrumentation.INSTANCE.beginFieldFetch(parameters);
+    }
+
+    @Override
+    public InstrumentationContext<CompletableFuture<ExecutionResult>> beginExecutionStrategy(
+            InstrumentationExecutionStrategyParameters parameters) {
+        return (result, exception) -> {};
     }
 }

--- a/src/main/java/io/leangen/graphql/execution/complexity/ComplexityAnalyzer.java
+++ b/src/main/java/io/leangen/graphql/execution/complexity/ComplexityAnalyzer.java
@@ -46,7 +46,9 @@ class ComplexityAnalyzer {
 
 
     ResolvedField collectFields(ExecutionContext context) {
-        FieldCollectorParameters parameters = FieldCollectorParameters.newParameters(context.getGraphQLSchema(), context.getGraphQLSchema().getQueryType())
+        FieldCollectorParameters parameters = FieldCollectorParameters.newParameters()
+                .schema(context.getGraphQLSchema())
+                .objectType(context.getGraphQLSchema().getQueryType())
                 .fragments(context.getFragmentsByName())
                 .variables(context.getVariables())
                 .build();


### PR DESCRIPTION
Note that the new `Instrumentation.beginExecutionStrategy` does nothing in `GraphQLRuntime.InstrumentationChain` and `ComplexityAnalysisInstrumentation` for the concerns of this PR.