### PR TITLE
Fixed operation name being returned instead of description.

### DIFF
--- a/src/main/java/io/leangen/graphql/generator/OperationMapper.java
+++ b/src/main/java/io/leangen/graphql/generator/OperationMapper.java
@@ -123,7 +123,7 @@ public class OperationMapper {
         GraphQLOutputType type = toGraphQLType(operation.getJavaType(), abstractTypes, buildContext);
         GraphQLFieldDefinition.Builder queryBuilder = newFieldDefinition()
                 .name(operation.getName())
-                .description(operation.getName())
+                .description(operation.getDescription())
                 .type(type);
 
         List<GraphQLArgument> arguments = operation.getArguments().stream()


### PR DESCRIPTION
Schema documentation wasn't returning the description specified with the @GraphQLQuery annotation.

This should fix it.