### PR TITLE
Ordering fields in GraphQL types and interfaces

### DIFF
--- a/src/main/java/io/leangen/graphql/annotations/types/GraphQLInterface.java
+++ b/src/main/java/io/leangen/graphql/annotations/types/GraphQLInterface.java
@@ -19,4 +19,6 @@ public @interface GraphQLInterface {
     boolean implementationAutoDiscovery() default false;
 
     String[] scanPackages() default {};
+
+    String[] fieldOrder() default {};
 }

--- a/src/main/java/io/leangen/graphql/annotations/types/GraphQLType.java
+++ b/src/main/java/io/leangen/graphql/annotations/types/GraphQLType.java
@@ -15,4 +15,6 @@ public @interface GraphQLType {
     String name();
 
     String description() default "";
+
+    String[] fieldOrder() default {};
 }

--- a/src/main/java/io/leangen/graphql/generator/mapping/common/InterfaceMapper.java
+++ b/src/main/java/io/leangen/graphql/generator/mapping/common/InterfaceMapper.java
@@ -2,6 +2,8 @@ package io.leangen.graphql.generator.mapping.common;
 
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -40,7 +42,9 @@ public class InterfaceMapper extends CachingMapper<GraphQLInterfaceType, GraphQL
                 .name(typeName)
                 .description(buildContext.typeInfoGenerator.generateTypeDescription(javaType));
 
-        List<GraphQLFieldDefinition> fields = objectTypeMapper.getFields(javaType, buildContext, operationMapper);
+        GraphQLInterface graphQLInterface = javaType.getAnnotation(GraphQLInterface.class);
+        List<String> fieldOrder = graphQLInterface != null ? Arrays.asList(graphQLInterface.fieldOrder()) : Collections.emptyList();
+        List<GraphQLFieldDefinition> fields = objectTypeMapper.getFields(javaType, fieldOrder, buildContext, operationMapper);
         fields.forEach(typeBuilder::field);
 
         typeBuilder.typeResolver(buildContext.typeResolver);

--- a/src/test/java/io/leangen/graphql/FieldOrderTest.java
+++ b/src/test/java/io/leangen/graphql/FieldOrderTest.java
@@ -1,0 +1,92 @@
+package io.leangen.graphql;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.introspection.IntrospectionQuery;
+import graphql.schema.GraphQLSchema;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLInterface;
+import io.leangen.graphql.annotations.types.GraphQLType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FieldOrderTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void test() {
+        ExecutionResult result = executeQuery(IntrospectionQuery.INTROSPECTION_QUERY);
+
+        List<String> characterFields = getTypeFieldsFromIntrospectionResult(result, "Character");
+        Assert.assertEquals(Arrays.asList("id", "name", "friends", "appearsIn", "_type_"), characterFields);
+
+        List<String> humanFields = getTypeFieldsFromIntrospectionResult(result, "Human");
+        Assert.assertEquals(Arrays.asList("id", "name", "friends", "appearsIn", "starships", "totalCredits", "_type_"), humanFields);
+
+        List<String> droidFields = getTypeFieldsFromIntrospectionResult(result, "Droid");
+        Assert.assertEquals(Arrays.asList("id", "_type_", "appearsIn", "friends", "name", "primaryFunction"), droidFields);
+    }
+
+    public static class Query {
+        @GraphQLQuery
+        public Character hero() { return null; }
+    }
+
+    @GraphQLInterface(name = "Character", implementationAutoDiscovery = true, fieldOrder = {"id", "name", "friends", "appearsIn"})
+    public static interface Character {
+        public String getId();
+        public String getName();
+        public String getFriends();
+        public String getAppearsIn();
+    }
+
+    @GraphQLType(name = "Human", fieldOrder = {"id", "name", "friends", "appearsIn", "starships", "totalCredits"})
+    public static class Human implements Character {
+        public String getId() { return null; }
+        public String getName() { return null; }
+        public String getFriends() { return null; }
+        public String getAppearsIn() { return null; }
+        public String getStarships() { return null; }
+        public String getTotalCredits() { return null; }
+    }
+
+    @GraphQLType(name = "Droid", fieldOrder = {"id" /*rest alphabetically*/})
+    public static class Droid implements Character {
+        public String getId() { return null; }
+        public String getName() { return null; }
+        public String getFriends() { return null; }
+        public String getAppearsIn() { return null; }
+        public String getPrimaryFunction() { return null; }
+    }
+
+    private static ExecutionResult executeQuery(String query) {
+        GraphQLSchema schema = new GraphQLSchemaGenerator()
+                .withBasePackage(FieldOrderTest.class.getPackage().getName())
+                .withOperationsFromSingletons(new Query())
+                .generate();
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult executionResult = graphQL.execute(query);
+        return executionResult;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> getTypeFieldsFromIntrospectionResult(ExecutionResult result, String typeName) {
+        Map<String, Object> data = result.getData();
+        Map<String, Object> __schema = (Map<String, Object>) data.get("__schema");
+        List<Map<String, Object>> types = (List<Map<String, Object>>) __schema.get("types");
+        Map<String, Object> type = types.stream()
+                .filter(t -> Objects.equals(t.get("name"), typeName))
+                .findFirst()
+                .get();
+        List<Map<String, Object>> fields = (List<Map<String, Object>>)type.get("fields");
+        return fields.stream()
+                .map(field -> (String) field.get("name"))
+                .collect(Collectors.toList());
+    }
+
+}


### PR DESCRIPTION
This change adds possibility to specify order of fields in GraphQL types and interfaces as discussed in #50.

Fields order can be specified using `@GraphQLType.fieldOrder` for types and `@GraphQLInterface.fieldOrder` for interfaces. Resulted list of fields will contain first fields from annotation in specified order and then rest of the fields in alphabetical order. This order is preserved in introspection query which is used by Graph*i*QL.

Note: order of fields doesn't have any impact on functionality but it is useful for documentation purposes.
