### PR TITLE
Empty description produced by PublicResolverBuilder

### DIFF
--- a/src/main/java/io/leangen/graphql/metadata/strategy/query/PublicResolverBuilder.java
+++ b/src/main/java/io/leangen/graphql/metadata/strategy/query/PublicResolverBuilder.java
@@ -64,7 +64,7 @@ public class PublicResolverBuilder extends FilteredResolverBuilder {
                 .filter(filters.stream().reduce(Predicate::and).orElse(ACCEPT_ALL))
                 .map(method -> new Resolver(
                         operationNameGenerator.generateQueryName(method, beanType, querySourceBean),
-                        operationNameGenerator.generateQueryName(method, beanType, querySourceBean),
+                        "",
                         method.isAnnotationPresent(Batched.class),
                         querySourceBean == null ? new MethodInvoker(method, beanType) : new SingletonMethodInvoker(querySourceBean, method, beanType),
                         getReturnType(method, beanType),
@@ -84,7 +84,7 @@ public class PublicResolverBuilder extends FilteredResolverBuilder {
                 .filter(filters.stream().reduce(Predicate::and).orElse(ACCEPT_ALL))
                 .map(method -> new Resolver(
                         operationNameGenerator.generateMutationName(method, beanType, querySourceBean),
-                        operationNameGenerator.generateMutationName(method, beanType, querySourceBean),
+                        "",
                         false,
                         querySourceBean == null ? new MethodInvoker(method, beanType) : new SingletonMethodInvoker(querySourceBean, method, beanType),
                         getReturnType(method, beanType),
@@ -104,7 +104,7 @@ public class PublicResolverBuilder extends FilteredResolverBuilder {
                 .filter(filters.stream().reduce(Predicate::and).orElse(ACCEPT_ALL))
                 .map(method -> new Resolver(
                         operationNameGenerator.generateSubscriptionName(method, beanType, querySourceBean),
-                        operationNameGenerator.generateSubscriptionName(method, beanType, querySourceBean),
+                        "",
                         false,
                         querySourceBean == null ? new MethodInvoker(method, beanType) : new SingletonMethodInvoker(querySourceBean, method, beanType),
                         getReturnType(method, beanType),


### PR DESCRIPTION
Currently `PublicResolverBuilder` puts name into description which doesn't look good in Graph*i*QL (and it is just duplicated information).

So this PR changes description produced by `PublicResolverBuilder` to empty string.

It is also more consistent with `AnnotatedResolverBuilder` since `@GraphQLQuery.description` is by default empty string.
