### PR TITLE
Customizable root type names in GraphQLSchemaGenerator

### DIFF
--- a/src/main/java/io/leangen/graphql/GraphQLSchemaGenerator.java
+++ b/src/main/java/io/leangen/graphql/GraphQLSchemaGenerator.java
@@ -150,9 +150,7 @@ public class GraphQLSchemaGenerator {
      * Default constructor
      */
     public GraphQLSchemaGenerator() {
-        this.queryRoot = "QUERY_ROOT";
-        this.mutationRoot = "MUTATION_ROOT";
-        this.subscriptionRoot = "SUBSCRIPTION_ROOT";
+        this("Query", "Mutation", "Subscription");
     }
 
     /**
@@ -165,18 +163,6 @@ public class GraphQLSchemaGenerator {
         this.queryRoot = queryRoot;
         this.mutationRoot = mutationRoot;
         this.subscriptionRoot = subscriptionRoot;
-    }
-
-    /**
-     * Construct with {@code serviceSingletons} as singleton query sources with default builders
-     * <p>Equivalent to: {@code new GraphQLSchemaGenerator().withOperationsFromType(serviceSingletons)}</p>
-     * <p>See {@link #withOperationsFromSingletons(Object...)}</p>
-     *
-     * @param serviceSingletons Singletons to register as query sources
-     */
-    public GraphQLSchemaGenerator(Object... serviceSingletons) {
-        this();
-        this.withOperationsFromSingletons(serviceSingletons);
     }
 
     /**
@@ -764,7 +750,10 @@ public class GraphQLSchemaGenerator {
     }
 
     private boolean isInternalType(GraphQLType type) {
-        return type.getName().startsWith("__") || type.getName().equals(queryRoot) || type.getName().equals(mutationRoot);
+        return type.getName().startsWith("__") ||
+                type.getName().equals(queryRoot) ||
+                type.getName().equals(mutationRoot) ||
+                type.getName().equals(subscriptionRoot);
     }
 
     private void checkType(Type type) {

--- a/src/main/java/io/leangen/graphql/GraphQLSchemaGenerator.java
+++ b/src/main/java/io/leangen/graphql/GraphQLSchemaGenerator.java
@@ -142,14 +142,30 @@ public class GraphQLSchemaGenerator {
     private final RelayMappingConfig relayMappingConfig = new RelayMappingConfig();
     private final Set<GraphQLType> additionalTypes = new HashSet<>();
 
-    private static final String QUERY_ROOT = "QUERY_ROOT";
-    private static final String MUTATION_ROOT = "MUTATION_ROOT";
-    private static final String SUBSCRIPTION_ROOT = "SUBSCRIPTION_ROOT";
+    private final String queryRoot;
+    private final String mutationRoot;
+    private final String subscriptionRoot;
 
     /**
      * Default constructor
      */
-    public GraphQLSchemaGenerator() {}
+    public GraphQLSchemaGenerator() {
+        this.queryRoot = "QUERY_ROOT";
+        this.mutationRoot = "MUTATION_ROOT";
+        this.subscriptionRoot = "SUBSCRIPTION_ROOT";
+    }
+
+    /**
+     * Constructor which allows to customize names of root types.
+     * @param queryRoot name of query root type
+     * @param mutationRoot name of mutation root type
+     * @param subscriptionRoot name of subscription root type
+     */
+    public GraphQLSchemaGenerator(String queryRoot, String mutationRoot, String subscriptionRoot) {
+        this.queryRoot = queryRoot;
+        this.mutationRoot = mutationRoot;
+        this.subscriptionRoot = subscriptionRoot;
+    }
 
     /**
      * Construct with {@code serviceSingletons} as singleton query sources with default builders
@@ -159,6 +175,7 @@ public class GraphQLSchemaGenerator {
      * @param serviceSingletons Singletons to register as query sources
      */
     public GraphQLSchemaGenerator(Object... serviceSingletons) {
+        this();
         this.withOperationsFromSingletons(serviceSingletons);
     }
 
@@ -711,7 +728,7 @@ public class GraphQLSchemaGenerator {
 
         GraphQLSchema.Builder builder = GraphQLSchema.newSchema()
                 .query(newObject()
-                        .name(QUERY_ROOT)
+                        .name(queryRoot)
                         .description("Query root type")
                         .fields(operationMapper.getQueries())
                         .build());
@@ -719,7 +736,7 @@ public class GraphQLSchemaGenerator {
         List<GraphQLFieldDefinition> mutations = operationMapper.getMutations();
         if (!mutations.isEmpty()) {
             builder.mutation(newObject()
-                    .name(MUTATION_ROOT)
+                    .name(mutationRoot)
                     .description("Mutation root type")
                     .fields(mutations)
                     .build());
@@ -728,7 +745,7 @@ public class GraphQLSchemaGenerator {
         List<GraphQLFieldDefinition> subscriptions = operationMapper.getSubscriptions();
         if (!subscriptions.isEmpty()) {
             builder.subscription(newObject()
-                    .name(SUBSCRIPTION_ROOT)
+                    .name(subscriptionRoot)
                     .description("Subscription root type")
                     .fields(subscriptions)
                     .build());
@@ -747,7 +764,7 @@ public class GraphQLSchemaGenerator {
     }
 
     private boolean isInternalType(GraphQLType type) {
-        return type.getName().startsWith("__") || type.getName().equals(QUERY_ROOT) || type.getName().equals(MUTATION_ROOT);
+        return type.getName().startsWith("__") || type.getName().equals(queryRoot) || type.getName().equals(mutationRoot);
     }
 
     private void checkType(Type type) {

--- a/src/test/java/io/leangen/graphql/GenericsTest.java
+++ b/src/test/java/io/leangen/graphql/GenericsTest.java
@@ -132,7 +132,7 @@ public class GenericsTest {
         
         GraphQL graphQL = GraphQL.newGraphQL(schemaWithDateIds).build();
         String jsonDate = valueMapperFactory.getValueMapper().toString(firstEvent);
-        String relayId = new Relay().toGlobalId("QUERY_ROOT", jsonDate);
+        String relayId = new Relay().toGlobalId("Query", jsonDate);
         ExecutionResult result = graphQL.execute("{ contains(id: \"" + relayId+ "\") }");
         assertTrue(ERRORS, result.getErrors().isEmpty());
         assertEquals(relayId, ((Map<String, Object>) result.getData()).get("contains"));


### PR DESCRIPTION
I would like to have root types with different names. For example query root type has currently name `QUERY_ROOT` but I would like to have it named `Query` which looks better in Graph*i*QL. It is small detail but it would be nice if graphql-spqr allowed everything what's possible using schema-first way.

This PR is just one way how to do it. It adds constructor to `GraphQLSchemaGenerator` which allows to pass root type names. I can change this PR however you like.

If you don't want this feature at all there is a workaround using `GraphQLSchemaProcessor`:
``` java
new GraphQLSchemaGenerator()
        .withOperationsFromSingletons(singletons)
        .withSchemaProcessors(schemaBuilder -> {
            final GraphQLSchema schema = schemaBuilder.build();
            return schemaBuilder
                    .query(renameGraphQLObjectType(schema.getQueryType(), "Query"))
                    .mutation(renameGraphQLObjectType(schema.getMutationType(), "Mutation"));
        })
        .generate();

private static GraphQLObjectType renameGraphQLObjectType(GraphQLObjectType objectType, String name) {
    if (objectType == null) {
        return null;
    }
    return buildGraphQLObjectType(objectType).name(name).build();
}

private static GraphQLObjectType.Builder buildGraphQLObjectType(GraphQLObjectType objectType) {
    final GraphQLObjectType.Builder builder = GraphQLObjectType.newObject()
            .name(objectType.getName())
            .description(objectType.getDescription())
            .fields(objectType.getFieldDefinitions())
            .definition(objectType.getDefinition());
    for (GraphQLOutputType outputType : objectType.getInterfaces()) {
        if (outputType instanceof GraphQLInterfaceType) {
            builder.withInterface((GraphQLInterfaceType) outputType);
        } else if (outputType instanceof GraphQLTypeReference) {
            builder.withInterface((GraphQLTypeReference) outputType);
        } else {
            throw new RuntimeException();
        }
    }
    return builder;
}
```
It is really brittle and ugly but it works.

As an alternative we could allow to rebuild `GraphQLObjectType` with different name which would make this workaround safer and shorter.