### PR TITLE
Add support for java.time.OffsetDateTime as GraphQL scalar.

### DIFF
--- a/src/main/java/io/leangen/graphql/util/Scalars.java
+++ b/src/main/java/io/leangen/graphql/util/Scalars.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.Period;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -132,9 +133,11 @@ public class Scalars {
     public static final GraphQLScalarType GraphQLLocalTime = temporalScalar(LocalTime.class, LocalTime::parse, i -> i.atZone(ZoneOffset.UTC).toLocalTime());
     
     public static final GraphQLScalarType GraphQLLocalDateTime = temporalScalar(LocalDateTime.class, LocalDateTime::parse, i -> i.atZone(ZoneOffset.UTC).toLocalDateTime());
-    
+
     public static final GraphQLScalarType GraphQLZonedDateTime = temporalScalar(ZonedDateTime.class, ZonedDateTime::parse, i -> i.atZone(ZoneOffset.UTC));
-    
+
+    public static final GraphQLScalarType GraphQLOffsetDateTime = temporalScalar(OffsetDateTime.class, OffsetDateTime::parse, i -> i.atOffset(ZoneOffset.UTC));
+
     public static final GraphQLScalarType GraphQLDurationScalar = temporalScalar(Duration.class, Duration::parse, instant -> Duration.ofMillis(instant.toEpochMilli()));
     
     public static final GraphQLScalarType GraphQLPeriodScalar = temporalScalar(Period.class, Period::parse, instant -> {
@@ -263,6 +266,7 @@ public class Scalars {
         scalarMapping.put(LocalTime.class, GraphQLLocalTime);
         scalarMapping.put(LocalDateTime.class, GraphQLLocalDateTime);
         scalarMapping.put(ZonedDateTime.class, GraphQLZonedDateTime);
+        scalarMapping.put(OffsetDateTime.class, GraphQLOffsetDateTime);
         scalarMapping.put(Duration.class, GraphQLDurationScalar);
         scalarMapping.put(Period.class, GraphQLPeriodScalar);
         scalarMapping.put(Locale.class, GraphQLLocale);

--- a/src/test/java/io/leangen/graphql/ScalarsTest.java
+++ b/src/test/java/io/leangen/graphql/ScalarsTest.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
@@ -56,11 +57,19 @@ public class ScalarsTest {
         testTemporal(ZonedDateTime.class, "2017-06-24T23:15:44.510Z", 1498346144510L);
     }
 
+    @Test
+    public void testOffsetDateTime() {
+        testTemporal(OffsetDateTime.class, "2017-06-24T23:15:44.510Z", "2017-06-24T22:15:44.510-01:00", 1498346144510L);
+    }
 
     private void testTemporal(Class type, String expected, long literal) {
+        testTemporal(type, expected, expected, literal);
+    }
+
+    private void testTemporal(Class type, String expected, String stringLiteral, long literal) {
         GraphQLScalarType scalar = Scalars.toGraphQLScalarType(type);
         testNullTemporalSerialization(scalar.getCoercing());
-        testStringTemporal(type, scalar.getCoercing(), expected);
+        testStringTemporal(type, scalar.getCoercing(), stringLiteral, stringLiteral);
         testEpochMilliTemporal(type, scalar.getCoercing(), expected, literal);
         testTemporalMapping(type, scalar);
     }
@@ -69,12 +78,12 @@ public class ScalarsTest {
         assertEquals(null, coercing.serialize(null));
     }
     
-    private void testStringTemporal(Class type, Coercing coercing, String expected) {
-        Object parsed = coercing.parseLiteral(new StringValue(expected));
+    private void testStringTemporal(Class type, Coercing coercing, String expected, String stringLiteral) {
+        Object parsed = coercing.parseLiteral(new StringValue(stringLiteral));
         assertTrue(type.isInstance(parsed));
         assertEquals(expected, coercing.serialize(parsed));
 
-        parsed = coercing.parseValue(expected);
+        parsed = coercing.parseValue(stringLiteral);
         assertTrue(type.isInstance(parsed));
         assertEquals(expected, coercing.serialize(parsed));
         


### PR DESCRIPTION
In a recent project I needed java.time.OffsetDateTime as a scalar, which was the only Java 8 date/time type missing support in SPQR. It might be of value to others, so I'd like to merge it back.