### PR TITLE
Java 10 class file format support by updating ASM to 6.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,12 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>6.0</version>
+            <version>6.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
-            <version>6.0</version>
+            <version>6.1.1</version>
         </dependency>
         <dependency>
             <groupId>io.leangen.geantyref</groupId>


### PR DESCRIPTION
When I use graphql-spqr in Java 10 project, annotation processing fails because of Java 10 byte code format. Updating ASM to 6.1.1 fixes this issue.