### PR TITLE
Changed default deprecation reason

### DIFF
--- a/src/main/java/io/leangen/graphql/metadata/strategy/query/PublicResolverBuilder.java
+++ b/src/main/java/io/leangen/graphql/metadata/strategy/query/PublicResolverBuilder.java
@@ -27,7 +27,7 @@ public class PublicResolverBuilder extends FilteredResolverBuilder {
     private String[] basePackages;
     private boolean javaDeprecation;
     private Function<Method, String> descriptionMapper = method -> "";
-    private Function<Method, String> deprecationReasonMapper = method -> javaDeprecation && method.isAnnotationPresent(Deprecated.class) ? "" : null;
+    private Function<Method, String> deprecationReasonMapper = method -> javaDeprecation && method.isAnnotationPresent(Deprecated.class) ? "Deprecated" : null;
 
     public PublicResolverBuilder() {
         this(new String[0]);

--- a/src/test/java/io/leangen/graphql/TypeInfoTest.java
+++ b/src/test/java/io/leangen/graphql/TypeInfoTest.java
@@ -71,7 +71,7 @@ public class TypeInfoTest {
 
             assertEquals(respectJavaDeprecation, field.isDeprecated());
             if (respectJavaDeprecation) {
-                assertEquals("", field.getDeprecationReason());
+                assertEquals("Deprecated", field.getDeprecationReason());
             }
         }
 


### PR DESCRIPTION
Currently GraphiQL console doesn't support fields with "" (empty string) deprecation reason. I'd like to have an ability to annotate a field as `@Deprecated` to achieve a deprecation in GraphiQL.