### PR TITLE
Make schema processors more flexible to support directives

### DIFF
--- a/src/main/java/io/leangen/graphql/GraphQLSchemaGenerator.java
+++ b/src/main/java/io/leangen/graphql/GraphQLSchemaGenerator.java
@@ -833,11 +833,12 @@ public class GraphQLSchemaGenerator {
                     .fields(subscriptions)
                     .build());
         }
-        applyProcessors(builder, buildContext);
 
         additionalTypes.addAll(buildContext.typeRepository.getDiscoveredTypes());
+        builder.additionalTypes(additionalTypes);
 
-        return builder.build(additionalTypes);
+        applyProcessors(builder, buildContext);
+        return builder.build();
     }
 
     private void applyProcessors(GraphQLSchema.Builder builder, BuildContext buildContext) {


### PR DESCRIPTION
Although SPQR doesn't have built-in support for directives, I have added them using a schema processor.

Unfortunately, the `GraphQLSchema.Builder.build()` method that SPQR currently uses doesn't apply the additionalDirectives and additionalTypes already in the builder. I believe this is a bug in graphql-java and have filed it as https://github.com/graphql-java/graphql-java/issues/1127, but this patch allows SPQR to work around it.