### PR TITLE
Introduce ConverterRegistryFactory

### DIFF
--- a/src/main/java/io/leangen/graphql/generator/mapping/ConverterRegistryFactory.java
+++ b/src/main/java/io/leangen/graphql/generator/mapping/ConverterRegistryFactory.java
@@ -1,0 +1,7 @@
+package io.leangen.graphql.generator.mapping;
+
+import java.util.List;
+
+public interface ConverterRegistryFactory {
+    ConverterRegistry create(List<InputConverter> inputConverters, List<OutputConverter> outputConverters);
+}


### PR DESCRIPTION
Hello,
we've faced with performance issue when retrieving many objects. It appears that about 25% of execution time for our query wasted in `AbstractTypeAdapter#supports` method. And it looks like there are no reasons to call it from `ConverterRegistry` every time we want to get `OutputConverter` for the same field of many object.

This pull request adds ability for customizing `ConverterRegistry`. For example it allows us to add caching in `ConverterRegistry`. I've tried add Guava cache to registry and it gave 10 times less execution times for simple benchmark. Benchmark results are here: https://github.com/spitty/spqr-converter-repository-test.

Another option to fix performance issue is to add cache in existing `ConverterRegistry`. But there are several questions to solve about its size, eviction policies and configuration options. Introducing `ConverterRegistryFactory` looks simpler.