### PR TITLE
Corrected the types in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,12 @@ Exposing the service with graphql-spqr:
 
 ```java
 UserService userService = new UserService(); //instantiate the service (or inject by Spring or another framework)
-GraphQLSchemaGenerator schema = new GraphQLSchemaGenerator()
+GraphQLSchema schema = new GraphQLSchemaGenerator()
     .withBasePackages("io.leangen") //not mandatory but strongly recommended to set your "root" packages
     .withOperationsFromSingleton(userService) //register the service
     .generate(); //done ;)
-GraphQL graphQL = new GraphQL(schema);
+GraphQL graphQL = new GraphQL.Builder(schema)
+	.build();
 
 //keep the reference to GraphQL instance and execute queries against it.
 //this operation selects a user by ID and requests name, regDate and twitterProfile fields only


### PR DESCRIPTION
Summary updates -
1. new GraphQL(schema) accepts `GraphQLSchema` and NOT `GraphQLSchemaGenerator`
2. Updated `GraphQL` creation to use builder. The constructor that was in use is deprecated.