### PR TITLE
Fix a NullPointerException in the Resolver class

### DIFF
--- a/src/main/java/io/leangen/graphql/metadata/Resolver.java
+++ b/src/main/java/io/leangen/graphql/metadata/Resolver.java
@@ -43,7 +43,7 @@ public class Resolver {
             validateBatching(executable.toString(), returnType, contextArguments);
         }
         
-        this.operationName = validateName(operationName);
+        this.operationName = validateName(operationName, executable);
         this.operationDescription = operationDescription;
         this.operationDeprecationReason = operationDeprecationReason;
         this.arguments = arguments;
@@ -54,7 +54,7 @@ public class Resolver {
         this.batched = batched;
     }
 
-    private String validateName(String operationName) {
+    private String validateName(String operationName, Executable executable) {
         if (Utils.isEmpty(operationName)) {
             throw new MappingException("The operation name for executable " + executable.toString() + " could not be determined");
         }


### PR DESCRIPTION
In `validateName` if the `operationName` is empty a `NullPointerException` was thrown since the field `executable` was not set yet in the constructor.

There are two easy fixes, one is by moving the assigning of the executable field before the call to `validateName`, the other one is to add the `executable` as a parameter to `validateName`. I chose the second option since then the order of the assignment of the fields in the constructor matches the order of the fields.

If the other fix is more desirable I can apply that fix instead.