### PR TITLE
Support Collections without type arguments

### DIFF
--- a/src/main/java/io/leangen/graphql/generator/mapping/common/CollectionOutputConverter.java
+++ b/src/main/java/io/leangen/graphql/generator/mapping/common/CollectionOutputConverter.java
@@ -21,9 +21,9 @@ public class CollectionOutputConverter implements OutputConverter {
     @Override
     public Object convertOutput(Object original, AnnotatedType type, ResolutionEnvironment resolutionEnvironment) {
         if (GenericTypeReflector.isSuperType(Collection.class, type.getType())) {
-            return processCollection((Collection<?>) original, (AnnotatedParameterizedType) type, resolutionEnvironment);
+            return processCollection((Collection<?>) original, type, resolutionEnvironment);
         }
-        return processMap((Map<?, ?>) original, (AnnotatedParameterizedType) type, resolutionEnvironment);
+        return processMap((Map<?, ?>) original, type, resolutionEnvironment);
     }
 
     @Override
@@ -32,17 +32,23 @@ public class CollectionOutputConverter implements OutputConverter {
                 || GenericTypeReflector.isSuperType(Map.class, type.getType());
     }
 
-    private List<?> processCollection(Collection<?> collection, AnnotatedParameterizedType type, ResolutionEnvironment resolutionEnvironment) {
+    private List<?> processCollection(Collection<?> collection, AnnotatedType type, ResolutionEnvironment resolutionEnvironment) {
+        AnnotatedParameterizedType collectionType =
+                (AnnotatedParameterizedType) GenericTypeReflector.getExactSuperType(type, Collection.class);
+
         return collection.stream()
-                .map(e -> resolutionEnvironment.convertOutput(e, type.getAnnotatedActualTypeArguments()[0]))
+                .map(e -> resolutionEnvironment.convertOutput(e, collectionType.getAnnotatedActualTypeArguments()[0]))
                 .collect(Collectors.toList());
     }
 
-    private Map<?, ?> processMap(Map<?, ?> map, AnnotatedParameterizedType type, ResolutionEnvironment resolutionEnvironment) {
+    private Map<?, ?> processMap(Map<?, ?> map, AnnotatedType type, ResolutionEnvironment resolutionEnvironment) {
+        AnnotatedParameterizedType mapType =
+                (AnnotatedParameterizedType) GenericTypeReflector.getExactSuperType(type, Map.class);
+
         Map<?, ?> processed = new LinkedHashMap<>();
         map.forEach((k, v) -> processed.put(
-                resolutionEnvironment.convertOutput(k, type.getAnnotatedActualTypeArguments()[0]),
-                resolutionEnvironment.convertOutput(v, type.getAnnotatedActualTypeArguments()[1])));
+                resolutionEnvironment.convertOutput(k, mapType.getAnnotatedActualTypeArguments()[0]),
+                resolutionEnvironment.convertOutput(v, mapType.getAnnotatedActualTypeArguments()[1])));
         return processed;
     }
 }


### PR DESCRIPTION
GraphQL SPQR currently checks for `Collection`/`Map` generic type parameters directly on the actual class. This works for most standard collections like `ArrayList` or `HashMap`, since they take the same generic arguments as their base classes. However, on cases like this...

```java
public class MyStringCollection implements Collection<String> {
    ...
}
```
...it fails at runtime because the class has no generic type arguments.

```java
java.lang.ClassCastException: class io.leangen.geantyref.AnnotatedTypeImpl cannot be cast to class java.lang.reflect.AnnotatedParameterizedType (io.leangen.geantyref.AnnotatedTypeImpl is in unnamed module of loader com.tripadvisor.core.configuration.FilteredClassLoader @768f4b42; java.lang.reflect.AnnotatedParameterizedType is in module java.base of loader 'bootstrap')
        at io.leangen.graphql.generator.mapping.common.CollectionOutputConverter.convertOutput(CollectionOutputConverter.java:24)
```

To fix this, `CollectionOutputConverter` should check the type parameters on the ancestor class (`Collection` or `Map`), not on the actual class.

(If this isn't clear, [my fork of the samples repo](https://github.com/ThomasJClark/graphql-spqr-samples/commit/458553e746bdabcba88093dfa74fe3ed1a8f6268) has a branch demonstrating this problem)