### PR TITLE
Use Defaults.class's class loader instead of thread context loader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.microprofile.sandbox</groupId>
+            <groupId>org.eclipse.microprofile.graphql</groupId>
             <artifactId>microprofile-graphql-api</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>

--- a/src/main/java/io/leangen/graphql/util/Defaults.java
+++ b/src/main/java/io/leangen/graphql/util/Defaults.java
@@ -38,7 +38,7 @@ public class Defaults {
 
     private static boolean isAvailable(JsonLib jsonLib) {
         try {
-            ClassUtils.forName(jsonLib.requiredClass);
+            ClassUtils.forName(jsonLib.requiredClass, ClassUtils.getClassLoader(Defaults.class));
             return true;
         } catch (ClassNotFoundException ge) {
             return false;


### PR DESCRIPTION
In my test case, I needed Jackson to be loadable from the `Defaults` class rather than the thread context class loader.  This required a small change to the `ClassUtils` class, and since my test framework uses Java 2 security, I added some doPrivs to ensure it works.  

I also updated the Microprofile API dependency to use the new repo's groupId rather than the sandbox.

The `testExplicitPlusDefaultMappers(io.leangen.graphql.SchemaGeneratorConfigurationTest)` test failed for me after these changes, but it failed before my changes too, so I don't think I did anything to break it.