### PR TITLE
add reason field to GraphQLIgnore annotation

### DIFF
--- a/src/main/java/io/leangen/graphql/annotations/GraphQLIgnore.java
+++ b/src/main/java/io/leangen/graphql/annotations/GraphQLIgnore.java
@@ -12,4 +12,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
 public @interface GraphQLIgnore {
+  
+  String reason() default "";
 }


### PR DESCRIPTION
add a quick field to document why this specific annotation is placed on a field.