### PR TITLE
Make clientMutationId optional

### DIFF
--- a/src/main/java/io/leangen/graphql/generator/OperationMapper.java
+++ b/src/main/java/io/leangen/graphql/generator/OperationMapper.java
@@ -320,7 +320,7 @@ public class OperationMapper {
                 .name(mutation.getName() + "Input")
                 .field(newInputObjectField()
                         .name(CLIENT_MUTATION_ID)
-                        .type(new GraphQLNonNull(GraphQLString)))
+                        .type(GraphQLString))
                 .fields(inputFields)
                 .build();
 
@@ -328,7 +328,7 @@ public class OperationMapper {
                 .name(payloadTypeName)
                 .field(newFieldDefinition()
                         .name(CLIENT_MUTATION_ID)
-                        .type(new GraphQLNonNull(GraphQLString)))
+                        .type(GraphQLString))
                 .fields(outputFields)
                 .build();
 


### PR DESCRIPTION
Created this PR to make the `clientMutationId` nullable during schema generation.

We have the requirement of Relay compliant mutations, however without the mutation ids in the current project I am working on, so I tried to find out whether they are actually specified as mandatory.

The [GraphQL Relay Server specification](https://relay.dev/docs/en/graphql-server-specification.html#mutations) is somewhat unclear when it comes to `clientMutationId` and whether it's a required field or not.

In the Relay Classic guides [here](https://relay.dev/docs/en/classic/classic-api-reference-relay-graphql-mutation#constructor) there is a description:
> That input argument should contain a (string) "clientMutationId" property for the purposes of reconciling requests and responses (automatically added by the Relay.GraphQLMutation API).
> The query should request "clientMutationId" as a subselection.

So that indicates that they are optional.

I found another PR doing something similar in another GraphQL library providing Relay capabilities here: https://github.com/api-platform/core/issues/2570, so looks like people are moving away from mandatory mutation ids.

btw, thanks heaps for the great work :+1: 