### PR TITLE
static fields should be omitted from generated schema

### DIFF
--- a/src/main/java/io/leangen/graphql/metadata/strategy/DefaultInclusionStrategy.java
+++ b/src/main/java/io/leangen/graphql/metadata/strategy/DefaultInclusionStrategy.java
@@ -20,7 +20,7 @@ public class DefaultInclusionStrategy implements InclusionStrategy {
 
     @Override
     public boolean includeOperation(List<AnnotatedElement> elements, AnnotatedType declaringType) {
-        return elements.stream().allMatch(element -> ClassUtils.isReal(element) && !isIgnored(element));
+        return elements.stream().allMatch(element -> ClassUtils.isReal(element) && !isIgnored(element) && !ClassUtils.isStatic(element));
     }
 
     @Override

--- a/src/main/java/io/leangen/graphql/util/ClassUtils.java
+++ b/src/main/java/io/leangen/graphql/util/ClassUtils.java
@@ -290,6 +290,14 @@ public class ClassUtils {
         throw new IllegalArgumentException("Can not determine if an element of type " + element.getClass().getName() + " is real");
     }
 
+    public static boolean isStatic(AnnotatedElement element) {
+        Objects.requireNonNull(element, "Element must not be null");
+        if (element instanceof Member) {
+            return Modifier.isStatic(((Member) element).getModifiers());
+        }
+        return false;
+    }
+
     public static String getFieldNameFromGetter(Method getter) {
         String name = getter.getName();
         if (name.startsWith("get") && name.length() > 3 && Character.isUpperCase(name.charAt(3))) {

--- a/src/test/java/io/leangen/graphql/FieldOrderTest.java
+++ b/src/test/java/io/leangen/graphql/FieldOrderTest.java
@@ -88,6 +88,8 @@ public class FieldOrderTest {
         public String climate;
         public String coordinates;
         public String size;
+
+        public static String shouldBeOmitted;
     }
 
     @GraphQLType(fieldOrder = {"episodeID", "title"})

--- a/src/test/java/io/leangen/graphql/ImplementationAutoDiscoveryTest.java
+++ b/src/test/java/io/leangen/graphql/ImplementationAutoDiscoveryTest.java
@@ -4,6 +4,7 @@ import graphql.schema.GraphQLSchema;
 import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLInterface;
+import io.leangen.graphql.annotations.types.GraphQLUnion;
 import io.leangen.graphql.generator.mapping.strategy.DefaultImplementationDiscoveryStrategy;
 import org.junit.Test;
 
@@ -65,23 +66,35 @@ public class ImplementationAutoDiscoveryTest {
 
     @GraphQLInterface(name = "Manual")
     interface Manual {
-        @GraphQLQuery String makeSchemaValidationPass = "";
+        @GraphQLQuery String makeSchemaValidationPass();
     }
 
     @GraphQLInterface(name = "Auto", implementationAutoDiscovery = true)
     interface Auto {
-        @GraphQLQuery String makeSchemaValidationPass = "";
+        @GraphQLQuery String makeSchemaValidationPass();
     }
 
     public static class One implements Manual, Auto {
         public String getOne() {
             return "one";
         }
+
+        @GraphQLQuery
+        @Override
+        public String makeSchemaValidationPass() {
+            return null;
+        }
     }
 
     public static class Two implements Manual, Auto {
         public String getTwo() {
             return "two";
+        }
+
+        @GraphQLQuery
+        @Override
+        public String makeSchemaValidationPass() {
+            return null;
         }
     }
 


### PR DESCRIPTION
Static fields (and methods) should not be included in schema. 

For example it fixes #390 
Also it will help use existing domain model (not annotated with spqr annotations). For example, if it contains fields like `static serialVersionUid`.

