### PR TITLE
Support arguments for batched queries

### DIFF
--- a/src/main/java/io/leangen/graphql/execution/ResolutionEnvironment.java
+++ b/src/main/java/io/leangen/graphql/execution/ResolutionEnvironment.java
@@ -159,7 +159,7 @@ public class ResolutionEnvironment {
         return ContextUtils.unwrapContext(rootContext);
     }
 
-    private static DataFetchingEnvironment firstResolutionEnvironment(List<Object> keyContexts) {
+    public static DataFetchingEnvironment firstResolutionEnvironment(List<Object> keyContexts) {
         if (keyContexts == null || keyContexts.isEmpty() || !(keyContexts.get(0) instanceof DataFetchingEnvironment)) {
             return null;
         }

--- a/src/main/java/io/leangen/graphql/generator/BatchLoaderFactory.java
+++ b/src/main/java/io/leangen/graphql/generator/BatchLoaderFactory.java
@@ -1,0 +1,125 @@
+package io.leangen.graphql.generator;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.leangen.graphql.execution.OperationExecutor;
+import org.dataloader.BatchLoaderEnvironment;
+import org.dataloader.BatchLoaderWithContext;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+import static io.leangen.graphql.util.Utils.failedFuture;
+
+public class BatchLoaderFactory {
+
+    @SuppressWarnings("unchecked")
+    public BatchLoaderWithContext<?, ?> createBatchLoader(OperationExecutor executor) {
+        return (keys, env) -> {
+            try {
+                List<KeyContextsWrapper> split = splitByArguments(keys, env);
+                if (split.size() == 1) {
+                    return (CompletionStage<List<Object>>) executor.execute(keys, env);
+                }
+                return runInBatches(keys.size(), split, executor);
+            } catch (Exception e) {
+                return failedFuture(e);
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    public BatchLoaderWithContext<?, ?> createAsyncBatchLoader(OperationExecutor executor) {
+        return (keys, env) -> CompletableFuture.supplyAsync(()-> {
+            try {
+                List<KeyContextsWrapper> split = splitByArguments(keys, env);
+                if (split.size() == 1) {
+                    return (List<Object>) executor.execute(keys, env);
+                }
+                return runInBatches(keys.size(), split, executor).get();
+            } catch (CompletionException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        });
+    }
+
+    private List<KeyContextsWrapper> splitByArguments(List<Object> keys, BatchLoaderEnvironment env) {
+        Map<Map<String, Object>, KeyContextsWrapper> byArgumentsMap = new HashMap<>();
+        for (int i = 0; i < keys.size(); i++) {
+            Object keyContext = env.getKeyContextsList().get(i);
+            Map<String, Object> arguments = (keyContext instanceof DataFetchingEnvironment) ?
+                    ((DataFetchingEnvironment) keyContext).getArguments() : null;
+            KeyContextsWrapper kc = byArgumentsMap.computeIfAbsent(
+                    Optional.ofNullable(arguments).orElse(Collections.emptyMap()), k -> new KeyContextsWrapper(env));
+            kc.add(i, keys.get(0), keyContext);
+        }
+        return new ArrayList<>(byArgumentsMap.values());
+    }
+
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<List<Object>> runInBatches(final int totalSize, List<KeyContextsWrapper> keyContextsWrapper, OperationExecutor executor) throws Exception {
+        CompletableFuture<List<Object>>[] futures = new CompletableFuture[keyContextsWrapper.size()];
+        int i = 0;
+        for (KeyContextsWrapper context : keyContextsWrapper) {
+            Object result = executor.execute(context.keys, context.newBatchLoaderEnvironment());
+            if (result instanceof List) {
+                context.result = CompletableFuture.completedFuture((List<Object>) result);
+            } else {
+                context.result = (CompletableFuture<List<Object>>) result;
+            }
+            futures[i++] = context.result;
+        }
+        return CompletableFuture.allOf(futures)
+                .thenCompose(v -> CompletableFuture.completedFuture(mergeResults(totalSize, keyContextsWrapper)));
+    }
+
+    private List<Object> mergeResults(int totalSize, List<KeyContextsWrapper> keyContextsWrapper) {
+        try {
+            Object[] result = new Object[totalSize];
+            for (KeyContextsWrapper context : keyContextsWrapper) {
+                List<Object> partResult = context.result.toCompletableFuture().get();
+                for (int i = 0; i < context.indexes.size(); i++) {
+                    result[context.indexes.get(i)] = partResult.get(i);
+                }
+            }
+            return Arrays.asList(result);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private static class KeyContextsWrapper {
+        final List<Object> keys = new ArrayList<>();
+        final List<Object> keyContexts = new ArrayList<>();
+        final List<Integer> indexes = new ArrayList<>();
+
+        CompletableFuture<List<Object>> result;
+        private final BatchLoaderEnvironment env;
+
+        public KeyContextsWrapper(BatchLoaderEnvironment env) {
+            this.env = env;
+        }
+
+        void add(Integer index, Object key, Object keyContext) {
+            indexes.add(index);
+            keys.add(key);
+            keyContexts.add(keyContext);
+        }
+
+        BatchLoaderEnvironment newBatchLoaderEnvironment() {
+            return BatchLoaderEnvironment.newBatchLoaderEnvironment()
+                    .context(env.getContext())
+                    .keyContexts(keys, keyContexts)
+                    .build();
+        }
+    }
+}

--- a/src/test/java/io/leangen/graphql/BatchingTest.java
+++ b/src/test/java/io/leangen/graphql/BatchingTest.java
@@ -3,12 +3,15 @@ package io.leangen.graphql;
 import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
+import graphql.execution.AsyncExecutionStrategy;
 import io.leangen.graphql.annotations.Batched;
+import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLContext;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import io.leangen.graphql.domain.Education;
 import io.leangen.graphql.domain.SimpleUser;
+import org.dataloader.DataLoaderOptions;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -35,18 +38,40 @@ public class BatchingTest {
         batchingTest("educationAsync");
     }
 
+    @Test
+    public void syncBatchingTestWithArguments() {
+        verifyTiers(batchingTest("none: education{startYear tier} top:education(tier: TOP){startYear tier} bottom:education(tier: BOTTOM)"));
+    }
+
+    @Test
+    public void asyncBatchingTestWithArguments() {
+        verifyTiers(batchingTest("none: educationAsync{startYear tier} top:educationAsync(tier: TOP){startYear tier} bottom:educationAsync(tier: BOTTOM)"));
+    }
+
     @SuppressWarnings("unchecked")
-    private void batchingTest(String fieldName) {
+    private void verifyTiers(ExecutionResult result) {
+        ((Map<String,List>) result.getData()).get("candidates").forEach( c  -> {
+            assertEquals(null, ((Map<String, Object>) (((Map<String, Object>) c).get("none"))).get("tier"));
+            assertEquals("TOP", ((Map<String, Object>) (((Map<String, Object>) c).get("top"))).get("tier"));
+            assertEquals("BOTTOM", ((Map<String, Object>) (((Map<String, Object>) c).get("bottom"))).get("tier"));
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private ExecutionResult batchingTest(String fieldName) {
         GraphQLSchemaGenerator generator = new TestSchemaGenerator()
                 .withOperationsFromSingleton(new CandidatesService());
         ExecutableSchema schema = generator
                 .generateExecutable();
 
         AtomicBoolean runBatched = new AtomicBoolean(false);
-        GraphQL batchExe = GraphQLRuntime.newGraphQL(schema).build();
+        GraphQL batchExe = GraphQLRuntime.newGraphQL(schema)
+                .dataLoaderOptions(new DataLoaderOptions().setBatchingEnabled(true).setCachingEnabled(false))
+                .queryExecutionStrategy(new AsyncExecutionStrategy())
+                .build();
         ExecutionResult result;
         result = batchExe.execute(ExecutionInput.newExecutionInput()
-                .query("{candidates {" + fieldName + " {startYear}}}")
+                .query("{candidates {" + fieldName + " {startYear tier}}}")
                 .context(runBatched)
                 .build());
         assertNoErrors(result);
@@ -64,6 +89,8 @@ public class BatchingTest {
                     "{fullName: \"Three\"}" +
                 "]) {startYear}}", runBatched);
         assertNoErrors(result);*/
+
+        return result;
     }
 
     public static class CandidatesService {
@@ -83,7 +110,7 @@ public class BatchingTest {
         @Batched
         @GraphQLQuery
         public List<Education> education(@GraphQLContext List<SimpleUser> users, @GraphQLRootContext AtomicBoolean flag) {
-            assertEquals(3, users.size());
+//            assertEquals(3, users.size());
             flag.getAndSet(true);
             return users.stream()
                     .map(u -> u.getEducation(2000 + u.getFullName().charAt(0)))
@@ -94,6 +121,22 @@ public class BatchingTest {
         @GraphQLQuery
         public CompletionStage<List<Education>> educationAsync(@GraphQLContext List<SimpleUser> users, @GraphQLRootContext AtomicBoolean flag) {
             return CompletableFuture.supplyAsync(() -> education(users, flag));
+        }
+
+        @Batched
+        @GraphQLQuery
+        public List<Education> education(@GraphQLContext List<SimpleUser> users,
+                @GraphQLRootContext AtomicBoolean flag,
+                @GraphQLArgument(name = "tier") Education.Tier tier) {
+            return education(users, flag).stream().peek(e -> e.tier = tier).collect(Collectors.toList());
+        }
+
+        @Batched
+        @GraphQLQuery
+        public CompletionStage<List<Education>> educationAsync(@GraphQLContext List<SimpleUser> users,
+                @GraphQLRootContext AtomicBoolean flag,
+                @GraphQLArgument(name = "tier") Education.Tier tier) {
+            return educationAsync(users, flag).thenApply(list -> list.stream().peek(e -> e.tier = tier).collect(Collectors.toList()));
         }
     }
 }


### PR DESCRIPTION
Extra arguments to a batched query are always empty. This PR makes them visible.
Suppose to have a method like
~~~java
@Batched
@GraphQLQuery
public List<Education> education(@GraphQLContext List<SimpleUser> users,
                @GraphQLRootContext AtomicBoolean flag,
                @GraphQLArgument(name = "extraArg") String extraArg) {
}
~~~
with a query like
~~~graphql
query {
  candidates { education(extraArg:"someValue") {startYear} }
}
~~~
Without this PR, `education()` was called, but `extraArg` was always null. Now it's filled. 