### PR TITLE
Fix bugs in ComplexityAnalyzer

### DIFF
--- a/src/main/java/io/leangen/graphql/execution/complexity/ComplexityAnalyzer.java
+++ b/src/main/java/io/leangen/graphql/execution/complexity/ComplexityAnalyzer.java
@@ -103,7 +103,6 @@ class ComplexityAnalyzer {
         return root;
     }
 
-    @SuppressWarnings("rawtypes")
     private Stream<Field> extractRootRawFields(List<Selection> selections, ExecutionContext context) {
         return selections.stream()
                 .flatMap(selection -> {

--- a/src/test/java/io/leangen/graphql/ComplexityTest.java
+++ b/src/test/java/io/leangen/graphql/ComplexityTest.java
@@ -13,6 +13,7 @@ import io.leangen.graphql.annotations.GraphQLNonNull;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLSubscription;
 import io.leangen.graphql.domain.Cat;
+import io.leangen.graphql.domain.Character;
 import io.leangen.graphql.domain.Dog;
 import io.leangen.graphql.domain.Education;
 import io.leangen.graphql.domain.Pet;
@@ -34,6 +35,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ComplexityTest {
+
+    private static final String unionQuery = "" +
+            "{" +
+            "  character(name: \"name\") {" +
+            "    ... on Human {" +
+            "      name" +
+            "      nickName" +
+            "    }" +
+            "    ... on Robot {" +
+            "      name" +
+            "    }" +
+            "  }" +
+            "}";
 
     private static final String fragmentOnRootQuery = "" +
             "{" +
@@ -162,6 +176,16 @@ public class ComplexityTest {
             "}";
 
     @Test
+    public void unionComplexityTest() {
+        testComplexity(
+                new CharacterService(),
+                unionQuery,
+                2,
+                3
+        );
+    }
+
+    @Test
     public void fragmentOnRootQueryComplexityTest() {
         testComplexity(
                 new PetService(),
@@ -259,6 +283,13 @@ public class ComplexityTest {
         @GraphQLQuery(name = "pets")
         public Page<Pet> findPets(@GraphQLArgument(name = "first") int first, @GraphQLArgument(name = "after") String after) {
             return PageFactory.createPage(Collections.emptyList(), PageFactory.offsetBasedCursorProvider(0L), false, false);
+        }
+    }
+
+    public static class CharacterService {
+        @GraphQLQuery(name = "character")
+        public Character findCharacter(@GraphQLArgument(name = "name") String name) {
+            return null;
         }
     }
 }

--- a/src/test/java/io/leangen/graphql/ComplexityTest.java
+++ b/src/test/java/io/leangen/graphql/ComplexityTest.java
@@ -35,6 +35,17 @@ import static org.junit.Assert.assertTrue;
 
 public class ComplexityTest {
 
+    private static final String fragmentOnRootQuery = "" +
+            "{" +
+            "  ... Cat" +
+            "}" +
+            "" +
+            "fragment Cat on Query {" +
+            "  pet(cat: true) {" +
+            "    sound" +
+            "  }" +
+            "}";
+
     private static final String fragmentQuery = "{" +
             "  newUsers: users(regDate: 1465667452785) {" +
             "    name" +
@@ -149,6 +160,16 @@ public class ComplexityTest {
             "       }" +
             "   }" +
             "}";
+
+    @Test
+    public void fragmentOnRootQueryComplexityTest() {
+        testComplexity(
+                new PetService(),
+                fragmentOnRootQuery,
+                1,
+                2
+        );
+    }
 
     @Test
     public void fragmentComplexityTest() {


### PR DESCRIPTION
I tested `ComplexityAnalyzer` on my GraphQL schema and I founded some issues.

1. `ComplexityAnalyzer` fails in case of fragment defined on `Query`
2. `ComplexityAnalyzer` doesn't calculate complexity for Union type 
(I also found the same issue #415)

In this PR I fix all of these issues and write some tests for its.