### PR TITLE
update graphql-java to 20.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>20.0</version>
+            <version>20.2</version>
         </dependency>
         <dependency>
             <groupId>com.graphql-java</groupId>


### PR DESCRIPTION
In graphql-java 20.0 was found critical issue https://security.snyk.io/vuln/SNYK-JAVA-COMGRAPHQLJAVA-5291199.
But in version 20.2 it was fixed. 

Releases [20.1](https://github.com/graphql-java/graphql-java/releases/tag/v20.1) and [20.2](https://github.com/graphql-java/graphql-java/releases/tag/v20.2) doesn't have breaking changes.

I create PR where graphql java version bump to 20.2.