### PR TITLE
Fix: Description for input fields not set correctly (@GraphQLInputField#description is ignored)

### DIFF
--- a/src/main/java/io/leangen/graphql/metadata/strategy/value/jackson/JacksonValueMapper.java
+++ b/src/main/java/io/leangen/graphql/metadata/strategy/value/jackson/JacksonValueMapper.java
@@ -116,7 +116,8 @@ public class JacksonValueMapper implements ValueMapper, InputFieldBuilder {
     private InputField toInputField(TypedElement element, BeanPropertyDefinition prop, ObjectMapper objectMapper, GlobalEnvironment environment) {
         AnnotatedType deserializableType = resolveDeserializableType(prop.getPrimaryMember(), element.getJavaType(), prop.getPrimaryType(), objectMapper);
         DefaultValue defaultValue = inputInfoGen.defaultValue(element.getElements(), element.getJavaType(), environment);
-        return new InputField(prop.getName(), prop.getMetadata().getDescription(), element, deserializableType, defaultValue);
+        String description = inputInfoGen.getDescription(element.getElements(), environment.messageBundle).orElse(null);
+        return new InputField(prop.getName(), description, element, deserializableType, defaultValue);
     }
 
     @Override

--- a/src/test/java/io/leangen/graphql/metadata/strategy/value/jackson/JacksonValueMapperTest.java
+++ b/src/test/java/io/leangen/graphql/metadata/strategy/value/jackson/JacksonValueMapperTest.java
@@ -1,0 +1,97 @@
+package io.leangen.graphql.metadata.strategy.value.jackson;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.leangen.geantyref.GenericTypeReflector;
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.execution.GlobalEnvironment;
+import io.leangen.graphql.metadata.InputField;
+import io.leangen.graphql.metadata.strategy.value.InputFieldBuilderParams;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+class ClassWithOneFieldWithADescription {
+    @GraphQLInputField(name = "field", description = "fancy field description")
+    private String field;
+}
+
+@Getter
+@Setter
+class ClassWithOneFieldWithAMultilineDescription {
+    @GraphQLInputField(name = "field", description = "fancy field description\nline two of fancy field description")
+    private String field;
+}
+
+@Getter
+@Setter
+class ClassWithOneFieldWithoutDescription {
+    @GraphQLInputField(name = "field")
+    private String field;
+}
+
+public class JacksonValueMapperTest {
+    private JacksonValueMapper jacksonValueMapper;
+
+    @Before
+    public void before() {
+        jacksonValueMapper = new JacksonValueMapper(new ObjectMapper());
+    }
+
+    private InputFieldBuilderParams generateInputFieldBuilderParamsForClass(Class<?> clazz) {
+        return InputFieldBuilderParams.builder()
+                .withType(GenericTypeReflector.annotate(clazz))
+                .withEnvironment(GlobalEnvironment.EMPTY)
+                .withConcreteSubTypes(Collections.emptyList())
+                .build();
+    }
+
+    @Test
+    public void fetchFieldsDescriptionFromAnnotation() {
+        // given
+        final String EXPECTED_DESCRIPTION = "fancy field description";
+        final InputFieldBuilderParams inputFieldBuilderParams = generateInputFieldBuilderParamsForClass(
+                ClassWithOneFieldWithADescription.class);
+
+        // when
+        InputField inputField = jacksonValueMapper.getInputFields(inputFieldBuilderParams).iterator().next();
+
+        // then
+        assertEquals(EXPECTED_DESCRIPTION, inputField.getDescription());
+    }
+
+    @Test
+    public void fetchFieldsMultilineDescriptionFromAnnotation() {
+        // given
+        final String EXPECTED_DESCRIPTION = "fancy field description\nline two of fancy field description";
+        final InputFieldBuilderParams inputFieldBuilderParams = generateInputFieldBuilderParamsForClass(
+                ClassWithOneFieldWithAMultilineDescription.class);
+
+        // when
+        InputField inputField = jacksonValueMapper.getInputFields(inputFieldBuilderParams).iterator().next();
+
+        // then
+        assertEquals(EXPECTED_DESCRIPTION, inputField.getDescription());
+    }
+
+    @Test
+    public void fetchFieldWithNoDescriptionInAnnotation() {
+        // when
+        final InputFieldBuilderParams inputFieldBuilderParams = generateInputFieldBuilderParamsForClass(
+                ClassWithOneFieldWithoutDescription.class);
+        InputField inputField = jacksonValueMapper.getInputFields(inputFieldBuilderParams).iterator().next();
+
+        // then
+        assertNull(inputField.getDescription());
+
+    }
+}


### PR DESCRIPTION
As I wrote here in my original thread: https://github.com/leangen/graphql-spqr/issues/466#issuecomment-1625892403
Descriptions set via the @GraphQLInputField annotation are not considered. I realized that when I printed the graphql schema by doing:

The source for the demo:
```Java
@GraphQLApi
@Component
public class DemoAPI {
    @GraphQLQuery(name = "demo")
    public DemoObject demoMethod(DemoObject demoObject) {
        return new DemoObject();
    }
}
```

```Java
@GraphQLType(name = "demo_object")
@Getter
@Setter
public class DemoObject {
    @GraphQLInputField(description = "important description\nabc")
    private String field;
}
```

The test class to generate the schema:
```Java
@SpringBootTest
class DemoApplicationTests {
    @Autowired
    private GraphQLSchema graphQLSchema;

    @Test
    void generateGraphQLSchema() throws IOException {
        String str = new SchemaPrinter().print(graphQLSchema);
        File newFile = new File("schema.graphqls");
        var fileWriter = new FileWriter(newFile);
        fileWriter.write(str);
        fileWriter.close();
    }
}
```

This will result in the following graphql schema:
```GraphQL
... Directives left out for readability

"Query root"
type Query {
  demo(demoObject: demo_objectInput): demo_object
}

type demo_object {
  field: String
}

input demo_objectInput {
  field: String
}
```

With the fix:
```GraphQL
... Directives left out for readability

"Query root"
type Query {
  demo(demoObject: demo_objectInput): demo_object
}

type demo_object {
  field: String
}

input demo_objectInput {
  """
  important description
  abc
  """
  field: String
}
```