### PR TITLE
Update graphql-java to 20.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>20.3</version>
+            <version>20.6</version>
         </dependency>
         <dependency>
             <groupId>com.graphql-java</groupId>


### PR DESCRIPTION
Bug fixes related to default values were released in [v20.5](https://github.com/graphql-java/graphql-java/releases/tag/v20.5).
However, that releases also introduced a bug where Guava classes were not shaded due to a configuration error. Therefore it is recommended to use [v20.6](https://github.com/graphql-java/graphql-java/releases/tag/v20.6) 
There are no mentions of breaking changes between [20.2 -> 20.6](https://github.com/graphql-java/graphql-java/compare/v20.2...20.x) 