### PR TITLE
Add LightOperationExecutor support for parameterless operations

### DIFF
--- a/src/main/java/io/leangen/graphql/execution/LightOperationExecutor.java
+++ b/src/main/java/io/leangen/graphql/execution/LightOperationExecutor.java
@@ -1,0 +1,146 @@
+package io.leangen.graphql.execution;
+
+import graphql.GraphQLException;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.LightDataFetcher;
+import io.leangen.graphql.generator.mapping.ArgumentInjector;
+import io.leangen.graphql.generator.mapping.ConverterRegistry;
+import io.leangen.graphql.generator.mapping.DelegatingOutputConverter;
+import io.leangen.graphql.metadata.Operation;
+import io.leangen.graphql.metadata.Resolver;
+import io.leangen.graphql.metadata.strategy.value.ValueMapper;
+import io.leangen.graphql.util.Utils;
+import jdk.jshell.spi.ExecutionControl;
+import org.dataloader.BatchLoaderEnvironment;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Created by soumik.dutta on 9/21/24.
+ * <p>
+ * LightOperationExecutor is a performance improvement over OperationExecutor for simple queries as it implements LightDataFetcher interface from GraphQL-Java <a href="https://github.com/graphql-java/graphql-java/pull/2953">#2953</a>
+ * <br>
+ * LightDataFetcher implementations do not require DataFetchingEnvironment for getting values and are considered cheaper to execute as DFE is not constructed for the query
+ */
+public class LightOperationExecutor extends OperationExecutor implements LightDataFetcher<Object> {
+
+    private final Operation operation;
+    private final ValueMapper valueMapper;
+    private final GlobalEnvironment globalEnvironment;
+    private final ConverterRegistry converterRegistry;
+    private final DerivedTypeRegistry derivedTypes;
+    private final Map<Resolver, List<ResolverInterceptor>> innerInterceptors;
+    private final Map<Resolver, List<ResolverInterceptor>> outerInterceptors;
+    private final Map<String, Object> NO_ARGUMENTS = new HashMap<>();
+
+
+    public LightOperationExecutor(Operation operation, ValueMapper valueMapper, GlobalEnvironment globalEnvironment, ResolverInterceptorFactory interceptorFactory) {
+        super(operation, valueMapper, globalEnvironment, interceptorFactory);
+        this.operation = operation;
+        this.valueMapper = valueMapper;
+        this.globalEnvironment = globalEnvironment;
+        this.converterRegistry = optimizeConverters(operation.getResolvers(), globalEnvironment.converters);
+        this.derivedTypes = deriveTypes(operation.getResolvers(), converterRegistry);
+        this.innerInterceptors = operation.getResolvers()
+                .stream()
+                .collect(Collectors.toMap(Function.identity(),
+                        res -> interceptorFactory.getInterceptors(new ResolverInterceptorFactoryParams(res))));
+        this.outerInterceptors = operation.getResolvers()
+                .stream()
+                .collect(Collectors.toMap(Function.identity(),
+                        res -> interceptorFactory.getOuterInterceptors(new ResolverInterceptorFactoryParams(res))));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> void sneakyThrow(Throwable t) throws T {
+        throw (T) t;
+    }
+
+    @Override
+    public Object get(GraphQLFieldDefinition fieldDefinition, Object sourceObject, Supplier<DataFetchingEnvironment> env) throws Exception {
+        // TODO: fix setting clientMutationId as this requires materialized DataFetchingEnvironment, something we are avoiding in LightOperationExecutor
+        // ContextUtils.setClientMutationId(env.getContext(), env.getArgument(CLIENT_MUTATION_ID));
+
+        Resolver resolver = this.operation.getApplicableResolver(NO_ARGUMENTS.keySet());
+        if (resolver == null) {
+            throw new GraphQLException(
+                    "Resolver for operation " + operation.getName() + " accepting arguments: " + NO_ARGUMENTS.keySet() + " not implemented");
+        }
+        ResolutionEnvironment resolutionEnvironment = new ResolutionEnvironment(resolver, env, this.valueMapper, this.globalEnvironment,
+                this.converterRegistry, this.derivedTypes);
+        return execute(resolver, resolutionEnvironment, sourceObject);
+    }
+
+    @Override
+    public Object get(DataFetchingEnvironment env) throws Exception {
+        throw new ExecutionControl.NotImplementedException(
+                "LightOperationExecutor does not require materialised DataFetchingEnvironment and so does not implement it. Use OperationExecutor instead.");
+    }
+
+    public Object execute(List<Object> keys, Map<String, Object> arguments, BatchLoaderEnvironment env) throws Exception {
+        Resolver resolver = this.operation.getApplicableResolver(arguments.keySet());
+        if (resolver == null) {
+            throw new GraphQLException("Batch loader for operation " + operation.getName() + " not implemented");
+        }
+        ResolutionEnvironment resolutionEnvironment = new ResolutionEnvironment(resolver, keys, env, this.valueMapper, this.globalEnvironment,
+                this.converterRegistry, this.derivedTypes);
+        return execute(resolver, resolutionEnvironment, arguments);
+    }
+
+    /**
+     * Prepares input arguments by calling respective {@link ArgumentInjector}s
+     * and invokes the underlying resolver method/field
+     *
+     * @param resolver              The resolver to be invoked once the arguments are prepared
+     * @param resolutionEnvironment An object containing all contextual information needed during operation resolution
+     * @param sourceObject          Object of which the method is being called
+     * @return The result returned by the underlying method/field, potentially proxied and wrapped
+     * @throws Exception If the invocation of the underlying method/field or any of the interceptors throws
+     */
+    private Object execute(Resolver resolver, ResolutionEnvironment resolutionEnvironment, Object sourceObject) throws Exception {
+        final Object[] NO_ARGUMENTS = new Object[]{};
+        InvocationContext invocationContext = new InvocationContext(operation, resolver, resolutionEnvironment, NO_ARGUMENTS);
+        Queue<ResolverInterceptor> interceptors = new ArrayDeque<>(this.outerInterceptors.get(resolver));
+        interceptors.add(
+                (ctx, cont) -> resolutionEnvironment.convertOutput(cont.proceed(ctx), resolver.getTypedElement(), resolver.getReturnType()));
+        interceptors.addAll(this.innerInterceptors.get(resolver));
+        interceptors.add((ctx, cont) -> {
+            try {
+                return resolver.resolve(sourceObject, NO_ARGUMENTS);
+            } catch (ReflectiveOperationException e) {
+                sneakyThrow(unwrap(e));
+            }
+            return null; //never happens, needed because of sneakyThrow
+        });
+        return execute(invocationContext, interceptors);
+    }
+
+    private Object execute(InvocationContext context, Queue<ResolverInterceptor> interceptors) throws Exception {
+        return interceptors.remove().aroundInvoke(context, (ctx) -> execute(ctx, interceptors));
+    }
+
+    private ConverterRegistry optimizeConverters(Collection<Resolver> resolvers, ConverterRegistry converters) {
+        return converters.optimize(resolvers.stream().map(Resolver::getTypedElement).collect(Collectors.toList()));
+    }
+
+    private DerivedTypeRegistry deriveTypes(Collection<Resolver> resolvers, ConverterRegistry converterRegistry) {
+        return new DerivedTypeRegistry(resolvers.stream().map(Resolver::getTypedElement).collect(Collectors.toList()),
+                Utils.extractInstances(converterRegistry.getOutputConverters(), DelegatingOutputConverter.class).collect(Collectors.toList()));
+    }
+
+    private Throwable unwrap(ReflectiveOperationException e) {
+        Throwable cause = e.getCause();
+        if (cause != null && cause != e) {
+            return cause;
+        }
+        return e;
+    }
+
+    public Operation getOperation() {
+        return operation;
+    }
+}

--- a/src/main/java/io/leangen/graphql/execution/OperationExecutor.java
+++ b/src/main/java/io/leangen/graphql/execution/OperationExecutor.java
@@ -4,6 +4,7 @@ import graphql.GraphQLException;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
 import io.leangen.graphql.generator.mapping.ArgumentInjector;
 import io.leangen.graphql.generator.mapping.ConverterRegistry;
 import io.leangen.graphql.generator.mapping.DelegatingOutputConverter;
@@ -13,10 +14,12 @@ import io.leangen.graphql.metadata.Resolver;
 import io.leangen.graphql.metadata.strategy.value.ValueMapper;
 import io.leangen.graphql.util.ContextUtils;
 import io.leangen.graphql.util.Utils;
+import jdk.jshell.spi.ExecutionControl;
 import org.dataloader.BatchLoaderEnvironment;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static io.leangen.graphql.util.GraphQLUtils.CLIENT_MUTATION_ID;
@@ -44,6 +47,11 @@ public class OperationExecutor implements DataFetcher<Object> {
                 res -> interceptorFactory.getInterceptors(new ResolverInterceptorFactoryParams(res))));
         this.outerInterceptors = operation.getResolvers().stream().collect(Collectors.toMap(Function.identity(),
                 res -> interceptorFactory.getOuterInterceptors(new ResolverInterceptorFactoryParams(res))));
+    }
+
+    public Object get(GraphQLFieldDefinition fieldDefinition, Object sourceObject, Supplier<DataFetchingEnvironment> env) throws Exception {
+        throw new ExecutionControl.NotImplementedException(
+                "OperationExecutor does not implement fetching DataFetchingEnvironment using a Supplier. Use LightOperationExecutor instead.");
     }
 
     @Override

--- a/src/main/java/io/leangen/graphql/generator/OperationMapper.java
+++ b/src/main/java/io/leangen/graphql/generator/OperationMapper.java
@@ -4,6 +4,7 @@ import graphql.relay.Relay;
 import graphql.schema.*;
 import io.leangen.geantyref.GenericTypeReflector;
 import io.leangen.graphql.annotations.GraphQLId;
+import io.leangen.graphql.execution.LightOperationExecutor;
 import io.leangen.graphql.execution.OperationExecutor;
 import io.leangen.graphql.generator.mapping.TypeMapper;
 import io.leangen.graphql.generator.mapping.TypeMappingEnvironment;
@@ -406,7 +407,11 @@ public class OperationMapper {
                 .filter(OperationArgument::isMappable)
                 .map(OperationArgument::getJavaType);
         ValueMapper valueMapper = buildContext.createValueMapper(inputTypes);
-        OperationExecutor executor = new OperationExecutor(operation, valueMapper, buildContext.globalEnvironment, buildContext.interceptorFactory);
+        OperationExecutor executor = operation.getArguments().isEmpty() ?
+                                     new LightOperationExecutor(operation, valueMapper, buildContext.globalEnvironment,
+                                             buildContext.interceptorFactory) :
+                                     new OperationExecutor(operation, valueMapper, buildContext.globalEnvironment,
+                                             buildContext.interceptorFactory);
         if (operation.isBatched()) {
             String loaderName = parentType + ':' + operation.getName();
             BatchLoaderWithContext<?, ?> batchLoader = batchloaderFactory.createBatchLoader(executor);

--- a/src/main/java/io/leangen/graphql/generator/mapping/common/DirectiveValueDeserializer.java
+++ b/src/main/java/io/leangen/graphql/generator/mapping/common/DirectiveValueDeserializer.java
@@ -11,20 +11,11 @@ import io.leangen.graphql.util.Utils;
 
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Parameter;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static graphql.introspection.Introspection.DirectiveLocation.FIELD;
-import static graphql.introspection.Introspection.DirectiveLocation.FRAGMENT_DEFINITION;
-import static graphql.introspection.Introspection.DirectiveLocation.FRAGMENT_SPREAD;
-import static graphql.introspection.Introspection.DirectiveLocation.INLINE_FRAGMENT;
-import static graphql.introspection.Introspection.DirectiveLocation.MUTATION;
-import static graphql.introspection.Introspection.DirectiveLocation.QUERY;
+import static graphql.introspection.Introspection.DirectiveLocation.*;
 
 public class DirectiveValueDeserializer implements ArgumentInjector {
 
@@ -33,7 +24,7 @@ public class DirectiveValueDeserializer implements ArgumentInjector {
     @Override
     public Object getArgumentValue(ArgumentInjectorParams params) {
         //Can happen inside BatchLoader
-        if (params.getResolutionEnvironment().dataFetchingEnvironment == null) {
+        if (params.getResolutionEnvironment().getDataFetchingEnvironment() == null) {
             //TODO Can this be supported? Since DataFetchingEnvs are saved as key contexts, it sounds possible.
           throw new IllegalArgumentException("Directive injection isn't supported in BatchLoaders");
         }
@@ -44,7 +35,12 @@ public class DirectiveValueDeserializer implements ArgumentInjector {
         String directiveName = Utils.coalesce(descriptor.name(), fallBackDirectiveName);
         Stream<Introspection.DirectiveLocation> locations = descriptor.locations().length != 0
                 ? Arrays.stream(descriptor.locations())
-                : sortedLocations(params.getResolutionEnvironment().dataFetchingEnvironment.getGraphQLSchema().getDirective(directiveName).validLocations());
+                :
+                                                            sortedLocations(params.getResolutionEnvironment()
+                                                                    .getDataFetchingEnvironment()
+                                                                    .getGraphQLSchema()
+                                                                    .getDirective(directiveName)
+                                                                    .validLocations());
         Directives directives = env.getDirectives();
         Stream<Map<String, Object>> rawValues = locations
                 .map(loc -> directives.find(loc, directiveName))

--- a/src/main/java/io/leangen/graphql/generator/mapping/common/EnvironmentInjector.java
+++ b/src/main/java/io/leangen/graphql/generator/mapping/common/EnvironmentInjector.java
@@ -27,11 +27,11 @@ public class EnvironmentInjector implements ArgumentInjector {
             return params.getResolutionEnvironment();
         }
         if (GenericTypeReflector.isSuperType(setOfStrings, params.getType().getType())) {
-            return params.getResolutionEnvironment().dataFetchingEnvironment.getSelectionSet().getImmediateFields()
+            return params.getResolutionEnvironment().getDataFetchingEnvironment().getSelectionSet().getImmediateFields()
                     .stream().map(SelectedField::getName).collect(Collectors.toSet());
         }
         if (MergedField.class.equals(raw)) {
-            return params.getResolutionEnvironment().dataFetchingEnvironment.getMergedField();
+            return params.getResolutionEnvironment().getDataFetchingEnvironment().getMergedField();
         }
         if (ValueMapper.class.isAssignableFrom(raw)) {
             return params.getResolutionEnvironment().valueMapper;

--- a/src/main/java/io/leangen/graphql/generator/mapping/common/IdAdapter.java
+++ b/src/main/java/io/leangen/graphql/generator/mapping/common/IdAdapter.java
@@ -2,17 +2,13 @@ package io.leangen.graphql.generator.mapping.common;
 
 import graphql.Scalars;
 import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLNamedType;
 import graphql.schema.GraphQLOutputType;
 import io.leangen.geantyref.GenericTypeReflector;
 import io.leangen.graphql.annotations.GraphQLId;
 import io.leangen.graphql.execution.GlobalEnvironment;
 import io.leangen.graphql.execution.ResolutionEnvironment;
-import io.leangen.graphql.generator.mapping.ArgumentInjector;
-import io.leangen.graphql.generator.mapping.ArgumentInjectorParams;
-import io.leangen.graphql.generator.mapping.InputConverter;
-import io.leangen.graphql.generator.mapping.OutputConverter;
-import io.leangen.graphql.generator.mapping.TypeMapper;
-import io.leangen.graphql.generator.mapping.TypeMappingEnvironment;
+import io.leangen.graphql.generator.mapping.*;
 import io.leangen.graphql.metadata.strategy.value.ValueMapper;
 
 import java.lang.reflect.AnnotatedElement;
@@ -43,7 +39,8 @@ public class IdAdapter implements TypeMapper, ArgumentInjector, OutputConverter<
     public String convertOutput(Object original, AnnotatedType type, ResolutionEnvironment resolutionEnvironment) {
         final String id = resolutionEnvironment.valueMapper.toString(original, type);
         if (type.getAnnotation(GraphQLId.class).relayId()) {
-            return resolutionEnvironment.globalEnvironment.relay.toGlobalId(resolutionEnvironment.parentType.getName(), id);
+            return resolutionEnvironment.globalEnvironment.relay.toGlobalId(
+                    ((GraphQLNamedType) resolutionEnvironment.getDataFetchingEnvironment().getParentType()).getName(), id);
         }
         return id;
     }

--- a/src/main/java/io/leangen/graphql/generator/mapping/core/PublisherAdapter.java
+++ b/src/main/java/io/leangen/graphql/generator/mapping/core/PublisherAdapter.java
@@ -75,7 +75,7 @@ public class PublisherAdapter<T> extends AbstractTypeSubstitutingMapper<Object> 
 
     @SuppressWarnings("WeakerAccess")
     protected Object convertOutputForNonSubscription(Publisher<T> original, AnnotatedType type, ResolutionEnvironment resolutionEnvironment) {
-        return collect(original, resolutionEnvironment.dataFetchingEnvironment.getExecutionStepInfo());
+        return collect(original, resolutionEnvironment.getDataFetchingEnvironment().getExecutionStepInfo());
     }
 
     @Override

--- a/src/test/java/io/leangen/graphql/InterceptorTest.java
+++ b/src/test/java/io/leangen/graphql/InterceptorTest.java
@@ -28,9 +28,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static io.leangen.graphql.support.LogAssertions.assertWarningsLogged;
-import static io.leangen.graphql.support.QueryResultAssertions.assertErrorsEqual;
-import static io.leangen.graphql.support.QueryResultAssertions.assertNoErrors;
-import static io.leangen.graphql.support.QueryResultAssertions.assertValueAtPathEquals;
+import static io.leangen.graphql.support.QueryResultAssertions.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -146,7 +144,7 @@ public class InterceptorTest {
         @Override
         public Object aroundInvoke(InvocationContext context, Continuation continuation) throws Exception {
             Auth auth = context.getResolver().getExecutable().getDelegate().getAnnotation(Auth.class);
-            User currentUser = context.getResolutionEnvironment().dataFetchingEnvironment.getContext();
+            User currentUser = context.getResolutionEnvironment().getDataFetchingEnvironment().getContext();
             if (auth != null && !currentUser.getRoles().containsAll(Arrays.asList(auth.rolesRequired()))) {
                 throw new IllegalAccessException("Access denied"); // or return null
             }


### PR DESCRIPTION
LightOperationExecutor is a performance improvement over OperationExecutor for simple queries as it implements `LightDataFetcher` interface from GraphQL-Java [#2953](https://github.com/graphql-java/graphql-java/pull/2953) and yields about 5% performance improvement in simple queries.

LightDataFetcher implementations do not require `DataFetchingEnvironment` for getting values and are considered cheaper to execute as DFE is not constructed for the query.

This also makes the `DataFetchingEnvironment` attribute of `ResolutionEnvironment` private and instead returns it via a getter since now it can either be a materialised object or wrapped in a `Supplier`.

However currently the following tests are failing which needs to be fixed. 
```
[ERROR] Failures: 
[ERROR]   RelayTest.testRelayMutations:110 Query result contains unexpected errors: [ExceptionWhileDataFetching{path=[upMe, result, 0, key], exception=jdk.jshell.spi.ExecutionControl$NotImplementedException: LightOperationExecutor does not require materialised DataFetchingEnvironment and so does not implement it. Use OperationExecutor instead., locations=[SourceLocation{line=1, column=169}]}, ExceptionWhileDataFetching{path=[upMe, result, 0, value], exception=jdk.jshell.spi.ExecutionControl$NotImplementedException: LightOperationExecutor does not require materialised DataFetchingEnvironment and so does not implement it. Use OperationExecutor instead., locations=[SourceLocation{line=1, column=179}]}]
[ERROR]   SchemaTest.testSchema:139 Query result contains unexpected errors: [ExceptionWhileDataFetching{path=[upMe, 0, key], exception=jdk.jshell.spi.ExecutionControl$NotImplementedException: LightOperationExecutor does not require materialised DataFetchingEnvironment and so does not implement it. Use OperationExecutor instead., locations=[SourceLocation{line=1, column=79}]}, ExceptionWhileDataFetching{path=[upMe, 0, value], exception=jdk.jshell.spi.ExecutionControl$NotImplementedException: LightOperationExecutor does not require materialised DataFetchingEnvironment and so does not implement it. Use OperationExecutor instead., locations=[SourceLocation{line=1, column=85}]}]
[ERROR]   SchemaTest.testSchema:139 Query result contains unexpected errors: [ExceptionWhileDataFetching{path=[upMe, 0, key], exception=jdk.jshell.spi.ExecutionControl$NotImplementedException: LightOperationExecutor does not require materialised DataFetchingEnvironment and so does not implement it. Use OperationExecutor instead., locations=[SourceLocation{line=1, column=79}]}, ExceptionWhileDataFetching{path=[upMe, 0, value], exception=jdk.jshell.spi.ExecutionControl$NotImplementedException: LightOperationExecutor does not require materialised DataFetchingEnvironment and so does not implement it. Use OperationExecutor instead., locations=[SourceLocation{line=1, column=85}]}]
[ERROR] Errors: 
[ERROR]   SubscriptionTest.nonNullPublisherSubscriptionTest:36->testSubscription:56 NullPointer
[ERROR]   SubscriptionTest.subscriptionTest:31->testSubscription:56 NullPointer
```