### PR TITLE
Fix ClassCastException when using @key directive on interfaces with Apollo Federation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,12 @@
             <version>1.18.38</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.apollographql.federation</groupId>
+            <artifactId>federation-graphql-java-support</artifactId>
+            <version>6.0.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/leangen/graphql/generator/OperationMapper.java
+++ b/src/main/java/io/leangen/graphql/generator/OperationMapper.java
@@ -1,5 +1,15 @@
 package io.leangen.graphql.generator;
 
+import graphql.language.ArrayValue;
+import graphql.language.BooleanValue;
+import graphql.language.EnumValue;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.language.NullValue;
+import graphql.language.ObjectField;
+import graphql.language.ObjectValue;
+import graphql.language.StringValue;
+import graphql.language.Value;
 import graphql.relay.Relay;
 import graphql.schema.*;
 import io.leangen.geantyref.GenericTypeReflector;
@@ -313,12 +323,45 @@ public class OperationMapper {
     }
 
     private GraphQLAppliedDirectiveArgument toGraphQLAppliedDirectiveArgument(DirectiveArgument directiveArgument, BuildContext buildContext) {
+        GraphQLInputType inputType = toGraphQLInputType(directiveArgument.getJavaType(), new TypeMappingEnvironment(directiveArgument.getTypedElement(), this, buildContext));
         GraphQLAppliedDirectiveArgument.Builder builder = GraphQLAppliedDirectiveArgument.newArgument()
                 .name(directiveArgument.getName())
                 .description(directiveArgument.getDescription())
-                .type(toGraphQLInputType(directiveArgument.getJavaType(), new TypeMappingEnvironment(directiveArgument.getTypedElement(), this, buildContext)))
-                .valueProgrammatic(directiveArgument.getValue());
+                .type(inputType)
+                .valueLiteral(toAstValue(directiveArgument.getValue()));
         return buildContext.transformers.transform(builder.build(), directiveArgument, this, buildContext);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Value<?> toAstValue(Object value) {
+        if (value == null) {
+            return NullValue.newNullValue().build();
+        } else if (value instanceof String) {
+            return StringValue.of((String) value);
+        } else if (value instanceof Boolean) {
+            return BooleanValue.of((Boolean) value);
+        } else if (value instanceof Integer) {
+            return IntValue.of((Integer) value);
+        } else if (value instanceof Long) {
+            return IntValue.newIntValue(java.math.BigInteger.valueOf((Long) value)).build();
+        } else if (value instanceof Number) {
+            return FloatValue.newFloatValue(new java.math.BigDecimal(value.toString())).build();
+        } else if (value instanceof Enum<?>) {
+            return EnumValue.of(((Enum<?>) value).name());
+        } else if (value instanceof Object[]) {
+            List<Value> values = new ArrayList<>();
+            for (Object element : (Object[]) value) {
+                values.add(toAstValue(element));
+            }
+            return ArrayValue.newArrayValue().values(values).build();
+        } else if (value instanceof Map) {
+            List<ObjectField> fields = new ArrayList<>();
+            for (Map.Entry<String, Object> entry : ((Map<String, Object>) value).entrySet()) {
+                fields.add(ObjectField.newObjectField().name(entry.getKey()).value(toAstValue(entry.getValue())).build());
+            }
+            return ObjectValue.newObjectValue().objectFields(fields).build();
+        }
+        return StringValue.of(value.toString());
     }
 
     private GraphQLFieldDefinition toRelayMutation(String parentType, GraphQLFieldDefinition mutation, DataFetcher<?> resolver, BuildContext buildContext) {

--- a/src/test/java/io/leangen/graphql/DirectiveTest.java
+++ b/src/test/java/io/leangen/graphql/DirectiveTest.java
@@ -4,6 +4,12 @@ import graphql.ExecutionInput;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.Scalars;
+import graphql.language.ArrayValue;
+import graphql.language.BooleanValue;
+import graphql.language.FloatValue;
+import graphql.language.IntValue;
+import graphql.language.ObjectValue;
+import graphql.language.StringValue;
 import graphql.schema.GraphQLAppliedDirective;
 import graphql.schema.GraphQLAppliedDirectiveArgument;
 import graphql.schema.GraphQLDirectiveContainer;
@@ -65,7 +71,7 @@ public class DirectiveTest {
         assertNotNull(metaDir);
         GraphQLAppliedDirectiveArgument metaArg = metaDir.getArgument("value");
         assertNotNull(metaArg);
-        assertEquals("meta", metaArg.getArgumentValue().getValue());
+        assertEquals("meta", ((graphql.language.StringValue) metaArg.getArgumentValue().getValue()).getValue());
 
         GraphQLInputObjectField inputField = inputType.getField("value");
         assertDirective(inputField, "inputFieldDef", "inputField");
@@ -147,9 +153,11 @@ public class DirectiveTest {
         assertEquals("WrapperInput", argType.getName());
         assertSame(Scalars.GraphQLString, argType.getFieldDefinition("name").getType());
         assertSame(Scalars.GraphQLString, argType.getFieldDefinition("value").getType());
-        Map<String, Object> wrapperRawValue = (Map<String, Object>) argument.getArgumentValue().getValue();
-        assertEquals(innerName, wrapperRawValue.get("name"));
-        assertEquals("test", wrapperRawValue.get("value"));
+        graphql.language.ObjectValue wrapperAstValue = (graphql.language.ObjectValue) argument.getArgumentValue().getValue();
+        java.util.function.Function<String, String> getField = name -> ((graphql.language.StringValue) wrapperAstValue.getObjectFields().stream()
+                .filter(f -> f.getName().equals(name)).findFirst().orElseThrow().getValue()).getValue();
+        assertEquals(innerName, getField.apply("name"));
+        assertEquals("test", getField.apply("value"));
     }
 
     private void assertClientDirectiveMapping(GraphQLSchema schema, String directiveName, String argumentName, DirectiveLocation... validLocations) {
@@ -335,5 +343,73 @@ public class DirectiveTest {
     @GraphQLDirective(locations = {DirectiveLocation.QUERY, DirectiveLocation.MUTATION})
     public static class Operation {
         public boolean enabled;
+    }
+
+    public enum Importance { LOW, HIGH }
+
+    @GraphQLDirective
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface AllTypes {
+        String  stringArg();
+        boolean boolArg();
+        int     intArg();
+        long    longArg();
+        double  doubleArg();
+        Importance enumArg();
+        String[] arrayArg();
+    }
+
+    @AllTypes(
+            stringArg = "hello",
+            boolArg   = true,
+            intArg    = 42,
+            longArg   = 100L,
+            doubleArg = 3.14,
+            enumArg   = Importance.HIGH,
+            arrayArg  = {"x", "y"})
+    private static class TypeWithAllTypesDirective {
+        @GraphQLQuery
+        public String id() { return "1"; }
+    }
+
+    private static class ServiceWithAllTypesDirective {
+        @GraphQLQuery
+        public TypeWithAllTypesDirective get() { return null; }
+    }
+
+    @Test
+    public void testDirectiveArgumentAstConversionCoversAllValueTypes() {
+        GraphQLSchema schema = new TestSchemaGenerator()
+                .withOperationsFromSingleton(new ServiceWithAllTypesDirective())
+                .generate();
+
+        GraphQLObjectType type = schema.getObjectType("TypeWithAllTypesDirective");
+        assertNotNull(type);
+        GraphQLAppliedDirective directive = type.getAppliedDirective("allTypes");
+        assertNotNull(directive);
+
+        assertEquals("hello",
+                ((StringValue) directive.getArgument("stringArg").getArgumentValue().getValue()).getValue());
+
+        assertEquals(true,
+                ((BooleanValue) directive.getArgument("boolArg").getArgumentValue().getValue()).isValue());
+
+        assertEquals(42,
+                ((IntValue) directive.getArgument("intArg").getArgumentValue().getValue()).getValue().intValue());
+
+        assertEquals(100L,
+                ((IntValue) directive.getArgument("longArg").getArgumentValue().getValue()).getValue().longValue());
+
+        assertEquals(3.14,
+                ((FloatValue) directive.getArgument("doubleArg").getArgumentValue().getValue()).getValue().doubleValue(), 0.001);
+
+        assertEquals("HIGH",
+                ((graphql.language.EnumValue) directive.getArgument("enumArg").getArgumentValue().getValue()).getName());
+
+        ArrayValue array = (ArrayValue) directive.getArgument("arrayArg").getArgumentValue().getValue();
+        assertEquals(2, array.getValues().size());
+        assertEquals("x", ((StringValue) array.getValues().get(0)).getValue());
+        assertEquals("y", ((StringValue) array.getValues().get(1)).getValue());
     }
 }

--- a/src/test/java/io/leangen/graphql/FederationCompatibilityTest.java
+++ b/src/test/java/io/leangen/graphql/FederationCompatibilityTest.java
@@ -1,0 +1,94 @@
+package io.leangen.graphql;
+
+import com.apollographql.federation.graphqljava.Federation;
+import graphql.language.StringValue;
+import graphql.schema.GraphQLAppliedDirective;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLDirective;
+import io.leangen.graphql.annotations.types.GraphQLInterface;
+import org.junit.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression test for https://github.com/leangen/graphql-spqr/issues/516
+ *
+ * Applied directive arguments must be stored as AST literals (e.g. StringValue),
+ * not as raw Java objects. Apollo Federation reads @key(fields: ...) by casting
+ * the argument value directly to StringValue, so valueProgrammatic caused a
+ * ClassCastException: String cannot be cast to StringValue.
+ */
+public class FederationCompatibilityTest {
+
+    @GraphQLDirective(name = "key")
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface Key {
+        String fields();
+    }
+
+    @Key(fields = "id")
+    @GraphQLInterface(name = "FederatedEntity")
+    public interface FederatedEntity {
+        @GraphQLQuery
+        String getId();
+    }
+
+    @Key(fields = "id")
+    public static class FederatedEntityImpl implements FederatedEntity {
+        @Override
+        public String getId() { return "1"; }
+    }
+
+    public static class FederatedEntityService {
+        @GraphQLQuery
+        public FederatedEntityImpl entity() { return new FederatedEntityImpl(); }
+    }
+
+    @Test
+    public void directiveArgumentsOnInterfacesAreStoredAsAstLiterals() {
+        GraphQLSchema schema = new GraphQLSchemaGenerator()
+                .withBasePackages("io.leangen.graphql")
+                .withOperationsFromSingleton(new FederatedEntityService())
+                .generate();
+
+        GraphQLInterfaceType interfaceType = schema.getTypeAs("FederatedEntity");
+        assertNotNull(interfaceType);
+
+        GraphQLAppliedDirective keyDirective = interfaceType.getAppliedDirective("key");
+        assertNotNull("@key directive not found on interface", keyDirective);
+
+        Object fieldsValue = keyDirective.getArgument("fields").getArgumentValue().getValue();
+        assertTrue("Directive argument must be an AST StringValue, not a raw " + fieldsValue.getClass().getSimpleName(),
+                fieldsValue instanceof StringValue);
+        assertEquals("id", ((StringValue) fieldsValue).getValue());
+    }
+
+    @Test
+    public void federationTransformSucceedsWithKeyDirectiveOnInterface() {
+        GraphQLSchema schema = new GraphQLSchemaGenerator()
+                .withBasePackages("io.leangen.graphql")
+                .withOperationsFromSingleton(new FederatedEntityService())
+                .generate();
+
+        GraphQLSchema federatedSchema = Federation.transform(schema)
+                .fetchEntities(env -> null)
+                .resolveEntityType(env -> env.getSchema().getObjectType("FederatedEntityImpl"))
+                .build();
+
+        // Federation adds _entities and _service fields to the query type
+        GraphQLObjectType queryType = federatedSchema.getQueryType();
+        assertNotNull(queryType.getField("_entities"));
+        assertNotNull(queryType.getField("_service"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #516

Applied directive arguments were being stored with `valueProgrammatic()`, which holds raw Java objects. Apollo Federation's `SchemaTransformer` reads `@key` directive arguments by casting the value directly to `graphql.language.StringValue`:

```java
// SchemaTransformer.java:189 (apollo federation)
.map(value -> (StringValue) value)  // ClassCastException — value is a java.lang.String
```

This causes the following exception when calling `Federation.transform(schema)` on a schema that has a `@key` directive applied to an interface:

```
java.lang.ClassCastException: class java.lang.String cannot be cast to class graphql.language.StringValue
    at com.apollographql.federation.graphqljava.SchemaTransformer.lambda$retrieveFieldSets$11(SchemaTransformer.java:189)
```

## Fix

Use `valueLiteral()` instead of `valueProgrammatic()` when building `GraphQLAppliedDirectiveArgument`. This stores values as graphql-java AST nodes (`StringValue`, `BooleanValue`, `IntValue`, etc.), which is the correct representation for schema-level directives.

A `toAstValue()` helper converts the Java annotation values produced by `AnnotationMappingUtils.destructureAnnotationArgument()` — which are always basic types (String, primitives, Enum, arrays, or nested Maps from nested annotations) — to their corresponding AST `Value<?>` nodes.

## Changes

- **`OperationMapper.java`**: `toGraphQLAppliedDirectiveArgument()` now uses `valueLiteral(toAstValue(value))` instead of `valueProgrammatic(value)`
- **`DirectiveTest.java`**: updated assertions — `getArgumentValue().getValue()` now correctly returns AST nodes (`StringValue`, `ObjectValue`) instead of raw Java objects for schema-level directives
- **`FederationCompatibilityTest.java`**: new regression test using `federation-graphql-java-support` (test scope) that reproduces issue #516 exactly — fails on the old code with the exact `ClassCastException` from the issue, passes with the fix
- **`pom.xml`**: added `federation-graphql-java-support:6.0.0` as a test dependency

To reproduce the bug on the current code before this fix, run `FederationCompatibilityTest` — it will throw `ClassCastException: String cannot be cast to StringValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)